### PR TITLE
WIP: rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 tera-proxy module that spawns large beacons on top of dead party members.
 
 ## Usage
-### `PartyDeathMarkers`
-- Toggle on/off
-- Default is on
+
+| Command | Description |
+|:-|:-|
+| `pdm toggle` | Toggles the module on/off. |
+| `pdm clear`  | Removes all present markers. |
+
+There is also a `partydeathmarkers` alias.
 
 ## Info
 - Tanks = red. Healers = blue. DPS = tall beacon.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const Command = require('command');
 
 module.exports = function PartyDeathMarkers(dispatch) {
     const command = Command(dispatch);
-    
+
     const DefaultItemSpawn = 98260;
     const UseJobSpecificMarkers = true;
     /*
@@ -13,134 +13,124 @@ module.exports = function PartyDeathMarkers(dispatch) {
     const JobSpecificMarkers = [
         {
             // tanks
-            jobs: [1, 10], 
+            jobs: [1, 10],
             marker: 91177
         },
         {
             // healers
-            jobs: [6, 7], 
+            jobs: [6, 7],
             marker: 91113
         }
     ];
-    
+
     let enabled = true;
-    let playerId = 0;
+    let myGameId = 0;
+    const deadPeople = new Map(); // playerId -> {loc}
     let partyMembers = [];
-    let spawnedBeacons = [];
-    
-    dispatch.hook('S_LOGIN', 10, (event) => {
-        playerId = event.playerId;
-        removeAllMarkers();
-    })
-        
-    dispatch.hook('S_PARTY_MEMBER_LIST', 7, (event) => {
-        partyMembers = event.members;
-    })
-    
-    dispatch.hook('S_DEAD_LOCATION', 2, (event) => {
-        for (let i = 0; i < partyMembers.length; i++) { 
-            if (partyMembers[i].gameId.equals(event.gameId)) {
-                spawnMarker(partyMembers[i].playerId, event.loc);
-                return;
-            }
+
+    dispatch.hook('S_LOGIN', '10', ({gameId}) => {
+        myGameId = gameId;
+        deadPeople.clear();
+    });
+
+    dispatch.hook('S_PARTY_MEMBER_LIST', 7, ({members}) => {
+        partyMembers = members.filter((mem) => !mem.gameId.equals(myGameId));
+    });
+
+    dispatch.hook('S_DEAD_LOCATION', 2, ({gameId, loc}) => {
+        const member = partyMembers.find((mem) => mem.gameId.equals(gameId));
+        if (member)
+            updateMarker(member, loc);
+    });
+
+    dispatch.hook('S_SPAWN_USER', 13, ({alive, gameId, loc}) => {
+        if (!alive) {
+            const member = partyMembers.find((mem) => mem.gameId.equals(gameId));
+            if (member)
+                updateMarker(member, loc);
         }
-    })
-    
-    dispatch.hook('S_SPAWN_USER', 13, (event) => {
-        if (!event.alive) {
-            for (let i = 0; i < partyMembers.length; i++) { 
-                if (partyMembers[i].gameId.equals(event.gameId)) {
-                    spawnMarker(partyMembers[i].playerId, event.loc);
-                    return;
-                }
-            }
+    });
+
+    dispatch.hook('S_PARTY_MEMBER_STAT_UPDATE', 3, ({playerId, curHp}) => {
+        if (deadPeople.has(playerId) && curHp > 0) {
+            removeMarker(playerId);
+            deadPeople.delete(playerId);
         }
-    })
-    
-    dispatch.hook('S_PARTY_MEMBER_STAT_UPDATE', 3, (event) => {
-        if (playerId == event.playerId) return;
-        
-        if (event.curHp > 0) {
-            for (let i = 0; i < partyMembers.length; i++) { 
-                if (partyMembers[i].playerId == event.playerId) {
-                    removeMarker(event.playerId);
-                    return;
-                }
-            }
-        }
-    })
-    
-    dispatch.hook('S_LEAVE_PARTY_MEMBER', 2, (event) => {
-        for (let i = 0; i < partyMembers.length; i++) {
-            if (partyMembers[i].playerId == event.playerId) {
-                removeMarker(partyMembers[i].gameId);
-            }
-        }
-    })
-    
-    dispatch.hook('S_LEAVE_PARTY', 1, (event) => {
-        removeAllMarkers();
+    });
+
+    dispatch.hook('S_LEAVE_PARTY_MEMBER', 2, ({playerId}) => {
+        removeMarker(playerId);
+        deadPeople.delete(playerId);
+        partyMembers = partyMembers.filter((mem) => mem.playerId === playerId);
+    });
+
+    dispatch.hook('S_LEAVE_PARTY', 'raw', () => {
         partyMembers = [];
-    })
-    
-    function spawnMarker(id, loc) {
-        if (!enabled) return;
-        if (playerId == id) return;
-        
-        removeMarker(id); //refresh
-        spawnedBeacons.push(id);
-        
+        deadPeople.forEach((k) => removeMarker(k));
+        deadPeople.clear();
+    });
+
+    function spawnMarker(member, loc) {
         dispatch.toClient('S_SPAWN_DROPITEM', 6, {
-            gameId: id,
+            // just use playerId as item's gameId; unlikely to have conflicts and easy to track
+            gameId: member.playerId,
             loc: loc,
-            item: getSpawnItem(id),
+            item: getSpawnItem(member.class),
             amount: 1,
+            explode: 1, // TOTEST
+            source: myGameId, // TOTEST
             expiry: 999999,
-            owners: [{playerId: playerId}]
+            owners: [{playerId: playerId}],
         });
     }
-    
-    function removeMarker(id) {
-        if (spawnedBeacons.includes(id)) {
-            let index = spawnedBeacons.indexOf(id);
-            spawnedBeacons.splice(index, 1);
-            
+
+    function updateMarker(member, loc) {
+        if (deadPeople.has(member.playerId))
+            removeMarker(member.playerId);
+        if (enabled)
+            spawnMarker(member, loc);
+        deadPeople.set(member.playerId, loc);
+    }
+
+    function removeMarker(playerId) {
+        if (deadPeople.has(playerId)) {
             dispatch.toClient('S_DESPAWN_DROPITEM', 4, {
-                gameId: id
+                gameId: playerId,
             });
         }
     }
-    
-    function removeAllMarkers() {
-        for (let i = 0; i < spawnedBeacons.length; i++) { 
-            removeMarker(spawnedBeacons[i]);
-        }
-        spawnedBeacons = [];
-    }
-    
-    function getSpawnItem(id) {
+
+    function getSpawnItem(jobId) {
         if (UseJobSpecificMarkers) {
-            let jobId;
-            for (let i = 0; i < partyMembers.length; i++) { 
-                if (partyMembers[i].playerId == id) {
-                    jobId = partyMembers[i].class;
-                }
-            }
-            
-            for (let i = 0; i < JobSpecificMarkers.length; i++) { 
-                if (JobSpecificMarkers[i].jobs.includes(jobId)) {
-                    return JobSpecificMarkers[i].marker;
+            for (const markers of JobSpecificMarkers) {
+                if (markers.jobs.includes(jobId)) {
+                    return markers.marker;
                 }
             }
         }
-        
+
         return DefaultItemSpawn;
     }
-    
-    command.add('partydeathmarkers', () => {
-        enabled = !enabled;
-        if (!enabled) removeAllMarkers();
-        command.message('(party-death-markers) ' + (enabled ? 'enabled' : 'disabled'));
+
+    command.add(['partydeathmarkers', 'pdm'], {
+        clear () {
+            deadPeople.forEach((k, v) => removeMarker(k));
+            deadPeople.clear();
+            command.message('Death markers cleared');
+        },
+        toggle () {
+            enabled = !enabled;
+            if (enabled) {
+                deadPeople.forEach((playerId, loc) => {
+                    const member = partyMembers.find((mem) => mem.playerId === playerId);
+                    if (member)
+                        spawnMarker(member, loc);
+                });
+            } else {
+                deadPeople.forEach((k, v) => removeMarker(k));
+            }
+
+            command.message("Death markers " + (enabled ? 'enabled' : 'disabled'));
+        },
     });
-    
 }


### PR DESCRIPTION
Hi there. I found a couple old modules on my old proxy instance from a year ago and updated them to the current patch while also applying a couple changes.

Currenlty WIP since I just adapted my changes that I made on top of 1.20 to this repo and **did not test** (due to lack of time).
I'll update this later when I actually verified that it works. I'm submitting this anyway in order for you to check out some changes and maybe review already.

Notable changes:

- When toggling, party state is still tracked and items/beacons are (de-)spawned appropriately.
- Instead of tracking the spawed beacons, track the dead players and their locations in a `Map`. 
- Uses other new-ish ES2016 features (or whatever version this is; I'm not a JS dev), like using for-of and object decomposition in parameters.
  I also didn't have any semi-colons in my version, so I might have missed adding one when adapting to your style.

I also used tera-game-state in my version, but afaik that's not available on Pinkie's fork of tera-proxy, so I resorted to tracking the gameId manually in order to not introduce a new dependency.